### PR TITLE
Placeholder when image not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,16 +113,16 @@ or as a regexp
 http://[0-9]+.media.tumblr.(com|de|net)
 ```  
 
-##### `fallback (array)` 
-If the image is not found a fallback image will can be shown. Each recipe can have its own fallback image, or when not defined, the default image is used.
+##### `placeholder (array)` 
+If the image is not found a placeholder image will can be shown. Each recipe can have its own placeholder image, or when not defined, the default image is used.
 The paths are relative to the base directory as defined above.
 
 ```php
 
-'fallback' => [
-  'default' => 'no_image.jpg', // default fallback image
+'placeholder' => [
+  'default' => 'no_image.jpg', // default placeholder image
 
-  'thumbs' => 'no_thumb_image.jpg', // fallback image for specific recipe
+  'thumbs' => 'no_thumb_image.jpg', // placeholder image for specific recipe
 ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,18 @@ or as a regexp
 http://[0-9]+.media.tumblr.(com|de|net)
 ```  
 
+##### `fallback (array)` 
+If the image is not found a fallback image will can be shown. Each recipe can have its own fallback image, or when not defined, the default image is used.
+The paths are relative to the base directory as defined above.
 
+```php
+
+'fallback' => [
+  'default' => 'no_image.jpg', // default fallback image
+
+  'thumbs' => 'no_thumb_image.jpg', // fallback image for specific recipe
+]
+```
 
 ## Image Processors
 

--- a/src/Thapp/JitImage/Controller/JitController.php
+++ b/src/Thapp/JitImage/Controller/JitController.php
@@ -106,12 +106,12 @@ class JitController extends Controller
 
         if(!$exists){
 
-            $fallback = $this->imageResolver->config->fallback;
+            $placeholder = $this->imageResolver->config->placeholder;
 
-            if(isset($fallback[$parameter]) and $fallback[$parameter]!=''){
-                $source = $fallback[$parameter];
-            }elseif(isset($fallback['default']) and $fallback['default']!=''){
-                $source = $fallback['default'];
+            if(isset($placeholder[$parameter]) and $placeholder[$parameter]!=''){
+                $source = $placeholder[$parameter];
+            }elseif(isset($placeholder['default']) and $placeholder['default']!=''){
+                $source = $placeholder['default'];
             }
 
             if($source=='' or !File::exists($this->imageResolver->config->base.'/'.$source)){

--- a/src/Thapp/JitImage/Controller/JitController.php
+++ b/src/Thapp/JitImage/Controller/JitController.php
@@ -11,6 +11,7 @@
 
 namespace Thapp\JitImage\Controller;
 
+use \Illuminate\Support\Facades\File;
 use \Illuminate\Routing\Router;
 use \Thapp\JitImage\ImageInterface;
 use \Illuminate\Routing\Controller;
@@ -100,6 +101,25 @@ class JitController extends Controller
      */
     public function getResource($parameter, $source)
     {
+
+        $exists = File::exists($this->imageResolver->config->base.'/'.$source);
+
+        if(!$exists){
+
+            $fallback = $this->imageResolver->config->fallback;
+
+            if(isset($fallback[$parameter]) and $fallback[$parameter]!=''){
+                $source = $fallback[$parameter];
+            }elseif(isset($fallback['default']) and $fallback['default']!=''){
+                $source = $fallback['default'];
+            }
+
+            if($source=='' or !File::exists($this->imageResolver->config->base.'/'.$source)){
+                return $this->notFound();
+            }
+
+        }
+
         if ($params = $this->recipes->resolve($parameter)) {
             extract($params);
             return $this->getImage($parameters, $source, $filter);

--- a/src/Thapp/JitImage/JitImageServiceProvider.php
+++ b/src/Thapp/JitImage/JitImageServiceProvider.php
@@ -178,7 +178,8 @@ class JitImageServiceProvider extends ServiceProvider
                         $config->getEnvironment(),
                         $config->get('jitimage::cache.environments', [])
                     ),
-                    'format_filter'  => $config->get('jitimage::filter.Convert', 'conv')
+                    'format_filter'  => $config->get('jitimage::filter.Convert', 'conv'),
+                    'fallback'       => $config->get('jitimage::fallback', [])
                 ];
                 return new \Thapp\JitImage\JitResolveConfiguration($conf);
             }

--- a/src/Thapp/JitImage/JitImageServiceProvider.php
+++ b/src/Thapp/JitImage/JitImageServiceProvider.php
@@ -179,7 +179,7 @@ class JitImageServiceProvider extends ServiceProvider
                         $config->get('jitimage::cache.environments', [])
                     ),
                     'format_filter'  => $config->get('jitimage::filter.Convert', 'conv'),
-                    'fallback'       => $config->get('jitimage::fallback', [])
+                    'placeholder'       => $config->get('jitimage::placeholder', [])
                 ];
                 return new \Thapp\JitImage\JitResolveConfiguration($conf);
             }

--- a/src/Thapp/JitImage/JitResolveConfiguration.php
+++ b/src/Thapp/JitImage/JitResolveConfiguration.php
@@ -36,7 +36,7 @@ class JitResolveConfiguration implements ResolverConfigInterface
      * @var mixed
      */
     protected static $allowedAttributes = [
-        'cache', 'base', 'trusted_sites', 'cache_prefix', 'cache_route', 'base_route', 'format_filter', 'fallback'
+        'cache', 'base', 'trusted_sites', 'cache_prefix', 'cache_route', 'base_route', 'format_filter', 'placeholder'
     ];
 
     /**

--- a/src/Thapp/JitImage/JitResolveConfiguration.php
+++ b/src/Thapp/JitImage/JitResolveConfiguration.php
@@ -36,7 +36,7 @@ class JitResolveConfiguration implements ResolverConfigInterface
      * @var mixed
      */
     protected static $allowedAttributes = [
-        'cache', 'base', 'trusted_sites', 'cache_prefix', 'cache_route', 'base_route', 'format_filter'
+        'cache', 'base', 'trusted_sites', 'cache_prefix', 'cache_route', 'base_route', 'format_filter', 'fallback'
     ];
 
     /**

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -126,5 +126,18 @@ return [
      * `generic` or `xsend`
      * ------------------------------------------------
      */
-    'response-type' => 'generic'
+    'response-type' => 'generic',
+
+     /* ------------------------------------------------
+     * if the image is not found a default image will be shown.
+     * each recipe can have its own fallback image:
+     *
+     *   'preview' => 'no_previes_available.jpg',
+     *
+     * the paths are relative to the base directory as defined above.
+     * ------------------------------------------------
+     */
+    'fallback' => [
+        'default' => '',
+    ]
 ];

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -130,14 +130,14 @@ return [
 
      /* ------------------------------------------------
      * if the image is not found a default image will be shown.
-     * each recipe can have its own fallback image:
+     * each recipe can have its own placeholder image:
      *
      *   'preview' => 'no_previes_available.jpg',
      *
      * the paths are relative to the base directory as defined above.
      * ------------------------------------------------
      */
-    'fallback' => [
+    'placeholder' => [
         'default' => '',
     ]
 ];


### PR DESCRIPTION
If a image can't be found a error is thrown, but sometime it would be helpful to return a placeholder image.

I made this feature configurable. A default placeholder can be defined but it's also possible to specify an image for each recipe. If not used the original NotFoundHttpException is still thrown.
